### PR TITLE
Enable pypi uploading of heospy package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 *.egg-info
 
+.tox

--- a/Readme.md
+++ b/Readme.md
@@ -34,27 +34,27 @@ python setup.py install
         heos_player player/set_volume -p level=19
         heos_player player/play_preset -p preset=3
         heos_player player/set_play_state -p state=stop
-        heos_player group/toggle_mute 
+        heos_player group/toggle_mute
         heos_player group/toggle_mute -p gid=-1352658342
-        
+
     Use the flag `--help` for a detailed help.
-    
+
 4. You can also execute a sequence of commands at once. The sequence can be
    given in a file:
-   
+
         heos_player -i cmds.txt
-        
+
    An example for `cmds.txt` is:
-   
+
         system/heart_beat
         # let's set a volume
         player/set_volume level=10
         # let's check if the volume is correct
-        player/get_volume 
+        player/get_volume
 
    Note that comments are possible and start with a `#`. You can also get the
    sequence of commands from `stdin`:
-   
+
         printf "system/heart_beat\nplayer/set_volume level=10\nplayer/get_volume" | heos_player -i -
 
 [specs]: http://rn.dmglobal.com/euheos/HEOS_CLI_ProtocolSpecification.pdf
@@ -71,7 +71,6 @@ If this player is a lead player in a group, this group is also the main group
 for commands starting with `group/`. Again, you can override this setting be
 explicitly mention the group id as a  parameter.
 
-    
 ## Usage with Raspberry Pi and Kodi
 
 If you have [OSMC][] or any other [Kodi Media center][Kodi] implementation on
@@ -84,19 +83,20 @@ your [Raspberry Pi][raspi], you can map certain actions for your HEOS on a
 [keymap]: http://kodi.wiki/view/Keymaps
 
 Example `keyboard.xml`-file:
-```
+
+```xml
 <keymap>
-  <global>
-    <keyboard>
-      <F1>RunScript(heos_player, player/play_preset, -p, preset=1)</F1>
-      <F2>RunScript(heos_player, player/play_preset, -p, preset=2)</F2>
-      <F3>RunScript(heos_player, player/play_preset, -p, preset=3)</F3>
-      <F4>RunScript(heos_player, player/play_preset, -p, preset=4)</F4>
-      <F12>RunScript(heos_player, player/set_play_state, -p, state=stop)</F12>
-    </keyboard>
-  </global>
-  <Home>
-  </Home>
+<global>
+<keyboard>
+<F1>RunScript(heos_player, player/play_preset, -p, preset=1)</F1>
+<F2>RunScript(heos_player, player/play_preset, -p, preset=2)</F2>
+<F3>RunScript(heos_player, player/play_preset, -p, preset=3)</F3>
+<F4>RunScript(heos_player, player/play_preset, -p, preset=4)</F4>
+<F12>RunScript(heos_player, player/set_play_state, -p, state=stop)</F12>
+</keyboard>
+</global>
+<Home>
+</Home>
 </keymap>
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+twine
+readme_renderer[md]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,46 @@
+[metadata]
+name = heospy
+author = Stephan Heuel
+author-email = mail@ping13.net
+maintainer = Stephan Heuel
+maintainer-email = mail@ping13.net
+summary = Control an HEOS player with a Python script
+description-file =
+    Readme.md
+description-content-type = text//markdown; charset=UTF-8
+home-page = https://github.com/ping13/heospy
+project_urls =
+    Bug Tracker = https://github.com/ping13/heospy/issues
+    Source Code = https://github.com/ping13/heospy.git
+requires-python = >=2.7
+
+license = Apache
+classifier =
+    Development Status :: 5 - Production/Stable
+    Environment :: Other Environment
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Internet :: WWW/HTTP
+keywords = api, heos, marantz, denon, audio
+
+[files]
+packages =
+    heospy
+
+[entry_points]
+console_scripts =
+    heos_player = heospy.heos_player:main
+
+[bdist_wheel]
+universal = 1
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,46 @@
+[tox]
+minversion = 3.2.1
+envlist = py27,py37,py36,py35,py34
+skip_missing_interpreters = true
+
+# workaround for https://github.com/tox-dev/tox/issues/149
+require =
+    tox-pip-extensions
+tox_pip_extensions_ext_venv_update = true
+
+[testenv]
+usedevelop = True
+# avoid using deps= due to https://github.com/tox-dev/tox/issues/149
+# hide deps from stdout https://github.com/tox-dev/tox/issues/601
+list_dependencies_command=echo
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+sitepackages=False
+commands=
+    bash -c 'find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf'
+    python -m pip check
+setenv =
+    PIP_LOG={envdir}/pip.log
+passenv =
+    PIP_*
+    TRAVIS
+    TRAVIS_*
+    XDG_CACHE_HOME
+envars =
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_USER=no
+whitelist_externals =
+    bash
+    echo
+    find
+    grep
+    rm
+    xargs
+
+[testenv:upload]
+commands=
+    rm -rf dist/
+    python setup.py sdist bdist_wheel
+    python -m twine check dist/*
+    python -m twine upload dist/*


### PR DESCRIPTION
Includes changes needed for testing the validity of package building
and uploading to PYPI.

To use just run "tox -e upload".

Fixes: #8